### PR TITLE
refactor(ci): add shared ci success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  node-checks:
+    name: Node Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.3.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check Node.js syntax
+        run: node --check index.js
+
+  python-checks:
+    name: Python Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Check Python syntax
+        run: python -m py_compile my_provider.py
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [node-checks, python-checks]
+    if: always()
+    timeout-minutes: 5
+    permissions:
+      checks: read
+      statuses: read
+
+    steps:
+      - name: Wait for all PR checks to succeed
+        uses: promptfoo/.github/.github/actions/ci-success@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          timeout-seconds: 300


### PR DESCRIPTION
Add a first CI workflow for redscan-lite with lightweight Node and Python validation, then add a CI Success job that uses the shared first-party action from promptfoo/.github. The workflow installs Node dependencies, checks index.js syntax, installs Python requirements, checks my_provider.py syntax, and rolls the results up under CI Success. Test plan: verify the workflow parses and CI Success waits for both validation jobs and any other PR checks on the commit.